### PR TITLE
Count URL length as Mastodon and don't truncate URLs

### DIFF
--- a/__tests__/mastodon-length.test.ts
+++ b/__tests__/mastodon-length.test.ts
@@ -1,0 +1,54 @@
+import { ValidationUtils } from '../nodes/Mastodon/Mastodon_Methods';
+
+describe('ValidationUtils.calculateMastodonLength', () => {
+	it('should return 0 for empty string', () => {
+		expect(ValidationUtils.calculateMastodonLength('')).toBe(0);
+	});
+
+	it('should return 23 for text that is only a URL', () => {
+		const text = 'https://example.com/very/long/path';
+		const length = ValidationUtils.calculateMastodonLength(text);
+
+		expect(length).toBe(23);
+	});
+
+	it('should return actual length when no URLs present', () => {
+		const text = 'Hello world';
+
+		const length = ValidationUtils.calculateMastodonLength(text);
+
+		expect(length).toBe(11);
+	});
+
+	it('should count short URL as 23 characters', () => {
+		// URL "https://example.com" = 19 chars actual, counts as 23
+		const text = 'Check https://example.com out';
+
+		const length = ValidationUtils.calculateMastodonLength(text);
+
+		// Actual: 29 chars
+		// Expected: 29 - 19 + 23 = 33
+		expect(length).toBe(33);
+	});
+
+	it('should count long URL as only 23 characters', () => {
+		// URL = 92 chars actual, counts as 23
+		const text = 'Read https://example.com/very/long/path/to/article/with/many/segments?param1=value1&param2=value2';
+
+		const length = ValidationUtils.calculateMastodonLength(text);
+
+		// Actual: 97 chars
+		// Expected: 97 - 92 + 23 = 28
+		expect(length).toBe(28);
+	});
+
+	it('should count multiple URLs correctly', () => {
+		const text = 'Check https://example.com and https://test.org for info';
+
+		const length = ValidationUtils.calculateMastodonLength(text);
+
+		// Total actual: 55
+		// Total effective: 6 + 23 + 5 + 23 + 9 = 66
+		expect(length).toBe(66);
+	});
+});

--- a/__tests__/url-extraction.test.ts
+++ b/__tests__/url-extraction.test.ts
@@ -1,0 +1,55 @@
+import { ValidationUtils } from '../nodes/Mastodon/Mastodon_Methods';
+
+describe('ValidationUtils.extractUrls', () => {
+	it('should return empty array when no URLs present', () => {
+		const text = 'Just some regular text without any links';
+		const urls = ValidationUtils.extractUrls(text);
+
+		expect(urls).toHaveLength(0);
+	});
+
+	it('should extract a simple HTTP URL', () => {
+		const text = 'Check out https://example.com for more info';
+		const urls = ValidationUtils.extractUrls(text);
+
+		expect(urls).toHaveLength(1);
+		expect(urls[0]).toEqual({
+			url: 'https://example.com',
+			startIndex: 10,
+			endIndex: 29,
+		});
+	});
+
+	it('should extract multiple URLs', () => {
+		const text = 'Visit https://example.com and http://test.org today';
+		const urls = ValidationUtils.extractUrls(text);
+
+		expect(urls).toHaveLength(2);
+		expect(urls[0].url).toBe('https://example.com');
+		expect(urls[1].url).toBe('http://test.org');
+	});
+
+	it('should extract URL with path and query parameters', () => {
+		const text = 'See https://example.com/path/to/page?id=123&ref=test#section2';
+		const urls = ValidationUtils.extractUrls(text);
+
+		expect(urls).toHaveLength(1);
+		expect(urls[0].url).toBe('https://example.com/path/to/page?id=123&ref=test#section2');
+	});
+
+	it('should extract URL at the start of text', () => {
+		const text = 'https://example.com is a great site';
+		const urls = ValidationUtils.extractUrls(text);
+
+		expect(urls).toHaveLength(1);
+		expect(urls[0].startIndex).toBe(0);
+	});
+
+	it('should extract URL at the end of text', () => {
+		const text = 'Visit https://example.com';
+		const urls = ValidationUtils.extractUrls(text);
+
+		expect(urls).toHaveLength(1);
+		expect(urls[0].endIndex).toBe(text.length);
+	});
+});

--- a/__tests__/url-truncation.test.ts
+++ b/__tests__/url-truncation.test.ts
@@ -1,0 +1,75 @@
+import { ValidationUtils } from '../nodes/Mastodon/Mastodon_Methods';
+
+describe('ValidationUtils.truncateWithUrlPreservation', () => {
+	it('should raise an error when passed non-string input', () => {
+		// @ts-expect-error - intentionally passing wrong type to test runtime check
+		expect(() => ValidationUtils.truncateWithUrlPreservation(123, 500))
+			.toThrow('Expected string parameter, got number');
+	})
+
+	it('should not truncate text within the character limit', () => {
+		const text = 'Short text with https://example.com';
+		const result = ValidationUtils.truncateWithUrlPreservation(text, 500);
+
+		expect(result).toBe(text);
+	});
+
+	it('should truncate plain text over the character characters', () => {
+		const text = 'a'.repeat(600);
+		const result = ValidationUtils.truncateWithUrlPreservation(text, 500);
+
+		expect(result.length).toBe(500);
+		expect(result).toBe('a'.repeat(500));
+	});
+
+	it('should preserve complete URL when truncating text after it', () => {
+		const prefix = 'a'.repeat(460);
+		const url = 'https://example.com/very/long/path/that/is/way/over/23/characters/long';
+		const suffix = 'b'.repeat(50);
+		const text = `${prefix} ${url} ${suffix}`;
+
+		const result = ValidationUtils.truncateWithUrlPreservation(text, 500);
+
+		// Should keep prefix (460) + space (1) + URL (70 actual, 23 effective) + space (1) = 485 effective, 532 actual
+		// Leaves room for 15 chars of suffix to reach 500 total, i.e. actual 547
+		expect(result).toBe(text.substring(0, 547));
+		expect(ValidationUtils.calculateMastodonLength(text)).toBe(535);
+	});
+
+	it('should truncate *before* URLs if we need to truncate a URL', () => {
+		// 495 chars + 1 space + URL (23 effective) = 519 effective
+		const prefix = 'a'.repeat(495);
+		const url = 'https://example.com/long/path';
+		const text = `${prefix} ${url}`;
+
+		const result = ValidationUtils.truncateWithUrlPreservation(text, 500);
+
+		// Should truncate before the URL
+		expect(result).toEqual(`${prefix} `);
+		expect(ValidationUtils.calculateMastodonLength(result)).toBe(496);
+	});
+
+	it('should preserve first URL and truncate after second URL', () => {
+		const text = 'Check https://example.com and https://test.org ' + 'x'.repeat(500);
+		const result = ValidationUtils.truncateWithUrlPreservation(text, 500);
+
+		expect(result).not.toBe(text);
+		// First URL: 19 actual → 23 effective (+4)
+		// Second URL: 16 actual → 23 effective (+7)
+		// URLs inflate effective length by 11, so truncate at 500 - 11 = 489
+		expect(result).toBe(text.substring(0, 500 - 4 - 7));
+		expect(ValidationUtils.calculateMastodonLength(result)).toBe(500);
+	});
+
+	it('should handle URL at the end of long text', () => {
+		const prefix = 'a'.repeat(476);
+		const url = 'https://example.com/some/path'; // 29 actual, 23 effective
+		const text = `${prefix} ${url}`;
+		// Effective: 476 + 1 + 23 = 500 (fits exactly)
+
+		const result = ValidationUtils.truncateWithUrlPreservation(text, 500);
+
+		expect(result).toBe(text); // Should not truncate
+		expect(ValidationUtils.calculateMastodonLength(text)).toBe(500);
+	});
+});

--- a/nodes/Mastodon/status/StatusMethods.ts
+++ b/nodes/Mastodon/status/StatusMethods.ts
@@ -13,7 +13,7 @@ function validateStatusParam(this: IExecuteFunctions, i: number): string {
 	if (!status) {
 		throw new NodeOperationError(this.getNode(), 'Status text is required');
 	}
-	return ValidationUtils.sanitizeStringParam(status as string, 500);
+	return ValidationUtils.truncateWithUrlPreservation(status as string, ValidationUtils.MASTODON_MAX_STATUS_LENGTH);
 }
 
 function validateStatusId(this: IExecuteFunctions, i: number): string {


### PR DESCRIPTION
This PR changes the truncation for statuses to be aware of how Mastodon count URL length and to ensure we handle that correctly, namely:

1. A URL is always normalized to 23 characters long, no matter if it's shorter or longer
   - This mimics behavior from Twitter, that Mastodon copied, where all URLs were run through their link shortener t.co, which made  all URLs 23 characters
   - I call this the `effective length` vs. the `actual length`, actual being the "raw length" without this normalization done. 🤷 on the terminology but it was what made sense to me as I was working 🙂
2. If any of the 23 effective characters of a URL is at the max status length, then remove the entire URL, because we can't truncate a part of a URL and get through Mastodon's validation
    - This corresponds to the existing behavior of this package in that it makes sure we can post even if it's too long
    - An example: `'a'.repeat(480) + '  https://example.com'` which has an actual length of 500 but an effective length of 504, we can't truncate it down to 500 because it'll still be detected as a URL and seen as 23. So all we can do is remove the URL

I was bitten by the truncation when I had a URL at the end of my status, and it was cut so the total status was 500 actual length, but clicking the URL led to a 404 because the truncated URL didn't exist on my site. 🙂 

I have tried to leave tests behind and explain the code, please ask away if something is unclear or if you'd like any changes. 🙂 

---

I introduced a couple of constants to keep these variables and name them, since I ended up using them in a couple of places.

The test does not use the constants because they are intended to verify that we don't accidentally change anything, so that's why we use the magic values there, but documented.

---

I installed my version of this package in n8n and did a test post, which went through as I expected:

<img width="620" height="316" alt="Personal_—_▶️_-_n8n" src="https://github.com/user-attachments/assets/9c74ed84-b87b-4fbb-b165-fca5189de4c3" />
