### PR TITLE
fix: skip npm publish when NPM_TOKEN is not set

### DIFF
--- a/.github/workflows/npm-publish_and_release.yml
+++ b/.github/workflows/npm-publish_and_release.yml
@@ -83,7 +83,12 @@ jobs:
           git push origin "v${{ env.TAG_NAME }}"
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ] || [ "$NODE_AUTH_TOKEN" = "" ]; then
+            echo "NPM_TOKEN not set — skipping publish"
+            exit 0
+          fi
+          pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Il workflow di release tentava `pnpm publish` su ogni push su main, fallendo con 404 perché il package non è registrato su npmjs.com. Ora salta gracefulmente il publish se il token non è configurato.