### PR TITLE
fix(release): use Node 22 for semantic-release compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
           cache: 'pnpm'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-the-mastodon",
-	"version": "0.0.36",
+	"version": "0.0.37",
 	"description": "Mastodon is a decentralized, open-source software that allows users to set up servers to communicate with each other.",
 	"keywords": [
 		"n8n",


### PR DESCRIPTION
semantic-release 25.x requires Node >=22.14.0. Updates workflow from Node 20 to 22 and aligns package.json version to 0.0.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)